### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ It will either throw an exception or extract the resources to the specified dire
      - **Android Runtime (Emulators and Devices):**
          - It will search for `libtor.so` within the application's `nativeLibraryDir` and return that path
          - All of this happens automatically and no configuration is needed.
-         - See the [core-resource-initializer][url-core-resource-initializer]
+         - See the [core-lib-locator][url-core-lib-locator]
      - **Android Unit Tests:**
          - You can add the `resource-android-unit-test` dependency and reflection will be used to
            source the correct `tor` binary resource for the given host/architecture that the tests 
@@ -265,5 +265,5 @@ TODO: gradle configuration for android
 [url-kotlin]: https://kotlinlang.org
 [url-kmp-tor]: https://github.com/05nelsonm/kmp-tor
 [url-kmp-tor-core]: https://github.com/05nelsonm/kmp-tor-core
-[url-core-resource-initializer]: https://github.com/05nelsonm/kmp-tor-core/tree/master/library/core-resource-initializer
+[url-core-lib-locator]: https://github.com/05nelsonm/kmp-tor-core/tree/master/library/core-lib-locator
 [url-task-image]: https://github.com/05nelsonm/kmp-tor-resource/assets/44778092/8be9197e-4135-43ad-9629-e18ef0e90523

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,13 +11,12 @@ gradle-kotlin = "1.9.21"
 gradle-publish-maven = "0.25.3"
 gradle-publish-npm = "3.4.1"
 
-kmp-tor-core = "2.0.0-alpha05"
-
+kmp-tor-core = "2.0.0-alpha06"
 kotlincrypto-hash = "0.4.0"
 kotlinx-cli = "0.3.6"
-kotlinx-datetime = "0.4.1"
+kotlinx-datetime = "0.5.0"
 
-okio = "3.6.0"
+okio = "3.7.0"
 
 [libraries]
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
@@ -33,8 +32,7 @@ gradle-publish-maven = { module = "com.vanniktech:gradle-maven-publish-plugin", 
 
 kmp-tor-core-api = { module = "io.matthewnelson.kmp-tor:core-api", version.ref = "kmp-tor-core" }
 kmp-tor-core-resource = { module = "io.matthewnelson.kmp-tor:core-resource", version.ref = "kmp-tor-core" }
-kmp-tor-core-resource-initializer = { module = "io.matthewnelson.kmp-tor:core-resource-initializer", version.ref = "kmp-tor-core" }
-
+kmp-tor-core-lib-locator = { module = "io.matthewnelson.kmp-tor:core-lib-locator", version.ref = "kmp-tor-core" }
 kotlincrypto-hash-sha2 = { module = "org.kotlincrypto.hash:sha2", version.ref = "kotlincrypto-hash" }
 kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli", version.ref = "kotlinx-cli" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }

--- a/library/resource-tor-gpl/build.gradle.kts
+++ b/library/resource-tor-gpl/build.gradle.kts
@@ -40,7 +40,7 @@ kmpConfiguration {
 
             sourceSetMain {
                 dependencies {
-                    implementation(libs.kmp.tor.core.resource.initializer)
+                    implementation(libs.kmp.tor.core.lib.locator)
                 }
             }
 

--- a/library/resource-tor/build.gradle.kts
+++ b/library/resource-tor/build.gradle.kts
@@ -40,7 +40,7 @@ kmpConfiguration {
 
             sourceSetMain {
                 dependencies {
-                    implementation(libs.kmp.tor.core.resource.initializer)
+                    implementation(libs.kmp.tor.core.lib.locator)
                 }
             }
 

--- a/library/resource-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/resource/tor/internal/-AndroidPlatform.kt
+++ b/library/resource-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/resource/tor/internal/-AndroidPlatform.kt
@@ -17,8 +17,8 @@ package io.matthewnelson.kmp.tor.resource.tor.internal
 
 import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.tor.resource.tor.TorResources
-import io.matthewnelson.kmp.tor.core.resource.initializer.KmpTorResourceInitializer
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.core.lib.locator.KmpTorLibLocator
 import io.matthewnelson.kmp.tor.core.resource.OSHost
 import io.matthewnelson.kmp.tor.core.resource.OSInfo
 import io.matthewnelson.kmp.tor.core.resource.Resource
@@ -55,11 +55,11 @@ internal actual val RESOURCE_CONFIG: Resource.Config by lazy {
             // to the nativeLib directory. This is required as
             // android does not allow execution from the app dir
             // (cannot download executables and run them).
-            if (KmpTorResourceInitializer.Impl.INSTANCE.findLib("libtor.so") != null) {
+            if (KmpTorLibLocator.find("libtor.so") != null) {
                 return@create
             }
 
-            if (KmpTorResourceInitializer.Impl.INSTANCE.isInitialized) {
+            if (KmpTorLibLocator.isInitialized()) {
                 error("""
                     Faild to find libtor.so within nativeLibraryDir
         
@@ -69,7 +69,7 @@ internal actual val RESOURCE_CONFIG: Resource.Config by lazy {
                     gradle.properties:   'android.bundle.enableUncompressedNativeLibs' is set to 'false'
                 """.trimIndent())
             } else {
-                error(KmpTorResourceInitializer.errorMsg())
+                error(KmpTorLibLocator.errorMsg())
             }
 
             return@create
@@ -127,6 +127,6 @@ internal actual val RESOURCE_CONFIG: Resource.Config by lazy {
 internal actual fun Map<String, File>.findLibTor(): Map<String, File> {
     if (contains(ALIAS_TOR)) return this
 
-    val lib = KmpTorResourceInitializer.Impl.INSTANCE.requireLib("libtor.so")
+    val lib = KmpTorLibLocator.require("libtor.so")
     return toMutableMap().apply { put(ALIAS_TOR, lib) }
 }

--- a/tools/diff-cli/core/build.gradle.kts
+++ b/tools/diff-cli/core/build.gradle.kts
@@ -45,14 +45,7 @@ kmpConfiguration {
         macosAll()
         mingwAll()
         tvosAll()
-
-        watchosArm32()
-        watchosArm64()
-        // Not supported by Okio
-        // See https://github.com/square/okio/issues/1381
-//        watchosDeviceArm64()
-        watchosX64()
-        watchosSimulatorArm64()
+        watchosAll()
 
         common {
             sourceSetMain {

--- a/tools/diff-cli/core/src/commonMain/kotlin/io/matthewnelson/diff/core/Diff.kt
+++ b/tools/diff-cli/core/src/commonMain/kotlin/io/matthewnelson/diff/core/Diff.kt
@@ -20,13 +20,9 @@ import io.matthewnelson.diff.core.internal.apply.Apply
 import io.matthewnelson.diff.core.internal.create.Create
 import io.matthewnelson.diff.core.internal.InternalDiffApi
 import io.matthewnelson.diff.core.internal.system
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import okio.*
 import okio.Path.Companion.toPath
 import kotlin.jvm.JvmField
-import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 


### PR DESCRIPTION
Updates `kmp-tor-core` to `2.0.0-alpha06`