### PR TITLE
Update `kmp-tor-common` dependency APIs

### DIFF
--- a/library/resource-exec-tor/src/commonTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-CommonTestPlatform.kt
+++ b/library/resource-exec-tor/src/commonTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-CommonTestPlatform.kt
@@ -20,5 +20,3 @@ import io.matthewnelson.kmp.file.File
 expect fun File.isExecutable(): Boolean
 
 expect val IS_WINDOWS: Boolean
-
-expect val SHARED_LIB_NAME: String

--- a/library/resource-exec-tor/src/execTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/ResourceLoaderExecUnitTest.kt
+++ b/library/resource-exec-tor/src/execTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/ResourceLoaderExecUnitTest.kt
@@ -50,7 +50,12 @@ open class ResourceLoaderExecUnitTest {
         val tor = loader.process(TestBinder) { tor, _ -> tor }
 
         // Ensures that it was extracted alongside the tor executable
-        val sharedLib = tor.parentFile!!.resolve(RESOURCE_CONFIG_TOR[ALIAS_LIB_TOR].platform.fsFileName)
+        val sharedLib = tor.parentFile!!.resolve(try {
+            RESOURCE_CONFIG_TOR[ALIAS_LIB_TOR].platform.fsFileName
+        } catch (_: NoSuchElementException) {
+            // Android Runtime
+            "libtor.so"
+        })
 
         // Ensure that only windows extracts a .local file for DLL redirect.
         val local = tor.parentFile!!.resolve("tor.exe.local")

--- a/library/resource-exec-tor/src/execTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/ResourceLoaderExecUnitTest.kt
+++ b/library/resource-exec-tor/src/execTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/ResourceLoaderExecUnitTest.kt
@@ -20,12 +20,15 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.file.*
 import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+import io.matthewnelson.kmp.tor.resource.exec.tor.internal.ALIAS_LIB_TOR
+import io.matthewnelson.kmp.tor.resource.exec.tor.internal.RESOURCE_CONFIG_TOR
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+@OptIn(InternalKmpTorApi::class)
 open class ResourceLoaderExecUnitTest {
 
     private object TestBinder: ResourceLoader.RuntimeBinder
@@ -47,7 +50,7 @@ open class ResourceLoaderExecUnitTest {
         val tor = loader.process(TestBinder) { tor, _ -> tor }
 
         // Ensures that it was extracted alongside the tor executable
-        val sharedLib = tor.parentFile!!.resolve(SHARED_LIB_NAME)
+        val sharedLib = tor.parentFile!!.resolve(RESOURCE_CONFIG_TOR[ALIAS_LIB_TOR].platform.fsFileName)
 
         // Ensure that only windows extracts a .local file for DLL redirect.
         val local = tor.parentFile!!.resolve("tor.exe.local")

--- a/library/resource-exec-tor/src/jsTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-JsTestPlatform.kt
+++ b/library/resource-exec-tor/src/jsTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-JsTestPlatform.kt
@@ -36,12 +36,3 @@ actual fun File.isExecutable(): Boolean {
 actual val IS_WINDOWS: Boolean by lazy {
     OSInfo.INSTANCE.osHost is OSHost.Windows
 }
-
-@OptIn(InternalKmpTorApi::class)
-actual val SHARED_LIB_NAME: String by lazy {
-    when (OSInfo.INSTANCE.osHost) {
-        is OSHost.Windows -> "tor.dll"
-        is OSHost.MacOS -> "libtor.dylib"
-        else -> "libtor.so"
-    }
-}

--- a/library/resource-exec-tor/src/jvmAndroidTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-JvmAndroidTestPlatform.kt
+++ b/library/resource-exec-tor/src/jvmAndroidTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-JvmAndroidTestPlatform.kt
@@ -26,12 +26,3 @@ actual fun File.isExecutable(): Boolean = canExecute()
 actual val IS_WINDOWS: Boolean by lazy {
     OSInfo.INSTANCE.osHost is OSHost.Windows
 }
-
-@OptIn(InternalKmpTorApi::class)
-actual val SHARED_LIB_NAME: String by lazy {
-    when (OSInfo.INSTANCE.osHost) {
-        is OSHost.Windows -> "tor.dll"
-        is OSHost.MacOS -> "libtor.dylib"
-        else -> "libtor.so"
-    }
-}

--- a/library/resource-exec-tor/src/nativeTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-NativeTestPlatform.kt
+++ b/library/resource-exec-tor/src/nativeTest/kotlin/io/matthewnelson/kmp/tor/resource/exec/tor/-NativeTestPlatform.kt
@@ -27,12 +27,3 @@ actual fun File.isExecutable(): Boolean = access(path, X_OK) == 0
 actual val IS_WINDOWS: Boolean by lazy {
     Platform.osFamily == OsFamily.WINDOWS
 }
-
-@OptIn(ExperimentalNativeApi::class)
-actual val SHARED_LIB_NAME: String by lazy {
-    when (Platform.osFamily) {
-        OsFamily.WINDOWS -> "tor.dll"
-        OsFamily.MACOSX -> "libtor.dylib"
-        else -> "libtor.so"
-    }
-}

--- a/library/resource-noexec-tor/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/internal/-JvmAndroidPlatform.kt
+++ b/library/resource-noexec-tor/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/internal/-JvmAndroidPlatform.kt
@@ -33,7 +33,7 @@ private class KmpTorApi: TorApi() {
 
     // TODO: tor_main JNI implementation. Issue #58.
 
-    override fun torRunMainProtected(args: Array<String>): Int {
+    override fun torRunMainProtected(args: Array<String>, log: Logger): Int {
         TODO("Not yet implemented")
     }
 

--- a/library/resource-noexec-tor/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/internal/-JvmAndroidPlatform.kt
+++ b/library/resource-noexec-tor/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/internal/-JvmAndroidPlatform.kt
@@ -38,30 +38,44 @@ private class KmpTorApi: TorApi() {
     }
 
     init {
+        val tempDir = TEMP_DIR
+
         try {
-            if (OSInfo.INSTANCE.isAndroidRuntime()) {
-                // libtor.so
+            if (tempDir == null) {
+                // Android Runtime. libtor.so
                 System.loadLibrary("tor")
             } else {
-                val tempDir = SysTempDir.resolve("kmp-tor_${UUID.randomUUID()}")
+                val libTor: File = RESOURCE_CONFIG_LIB_TOR
+                    .extractTo(tempDir, onlyIfDoesNotExist = false)
+                    .getValue(ALIAS_LIB_TOR)
 
-                try {
-                    val libTor: File = RESOURCE_CONFIG_LIB_TOR
-                        .extractTo(tempDir, onlyIfDoesNotExist = false)
-                        .getValue(ALIAS_LIB_TOR)
-
-                    System.load(libTor.absolutePath)
-
-                    tempDir.deleteOnExit()
-                    libTor.deleteOnExit()
-                } catch (t: Throwable) {
-                    tempDir.deleteRecursively()
-                    throw t
-                }
+                System.load(libTor.absolutePath)
             }
         } catch (t: Throwable) {
             if (t is IOException) throw t
             throw IllegalStateException("Failed to dynamically load tor library", t)
+        }
+    }
+
+    private companion object {
+
+        private val TEMP_DIR: File? by lazy {
+            if (OSInfo.INSTANCE.isAndroidRuntime()) return@lazy null
+
+            val tempDir = SysTempDir.resolve("kmp-tor_${UUID.randomUUID()}")
+
+            val libTor = try {
+                tempDir.resolve(RESOURCE_CONFIG_LIB_TOR[ALIAS_LIB_TOR].platform.fsFileName)
+            } catch (_: NoSuchElementException) {
+                // Is possible with android unit tests if the dependency is not present.
+                // Will result in an error upon extraction attempt. Ignore it here.
+                null
+            }
+
+            tempDir.deleteOnExit()
+            libTor?.deleteOnExit()
+
+            tempDir
         }
     }
 }

--- a/library/resource-noexec-tor/src/loadableTest/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderNoExecUnitTest.kt
+++ b/library/resource-noexec-tor/src/loadableTest/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderNoExecUnitTest.kt
@@ -20,12 +20,10 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.file.SysTempDir
 import io.matthewnelson.kmp.file.readBytes
 import io.matthewnelson.kmp.file.resolve
-import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.api.ResourceLoader
 import kotlin.random.Random
 import kotlin.test.*
 
-@OptIn(InternalKmpTorApi::class)
 open class ResourceLoaderNoExecUnitTest {
 
     private object TestBinder: ResourceLoader.RuntimeBinder
@@ -70,14 +68,17 @@ open class ResourceLoaderNoExecUnitTest {
             return
         }
 
-        try {
+        val result = try {
             loader.withApi(TestBinder) {
                 torRunMain(listOf("--version"))
             }
         } catch (e: NotImplementedError) {
+            // TODO: Remove. Issue #58
             println("Skipping...")
             return
         }
+
+        assertEquals(0, result)
     }
 
     @Test
@@ -90,7 +91,7 @@ open class ResourceLoaderNoExecUnitTest {
             return
         }
 
-        try {
+        val result = try {
             loader.withApi(TestBinder) {
                 torRunMain(listOf(
                     "--SocksPort", "-1",
@@ -98,14 +99,12 @@ open class ResourceLoaderNoExecUnitTest {
                     "--quiet",
                 ))
             }
-
-            fail("Tor completed without expected exception...")
         } catch (e: NotImplementedError) {
             // TODO: Remove. Issue #58
             println("Skipping...")
             return
-        } catch (e: IllegalArgumentException) {
-            // pass
         }
+
+        assertEquals(-1, result)
     }
 }


### PR DESCRIPTION
Pushed an update to `kmp-tor-common` SNAPSHOT. This updates things for it.