### PR TITLE
Add tests for when `jniLibs.useLegacyPackaging = false`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -207,7 +207,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 21, 23, 24, 26, 29, 30, 31, 32, 33, 34, 35 ]
+        api-level: [ 21, 23, 24, 29, 30, 31, 32, 33, 34, 35 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ gradle-publish-maven        = "0.32.0"
 gradle-publish-npm          = "3.5.3"
 
 kmp-tor-common              = "2.3.0-SNAPSHOT"
-kotlincrypto-catalog        = "0.7.0" # Utilized from settings.gradle.kts
+kotlincrypto-catalog        = "0.7.1" # Utilized from settings.gradle.kts
 kotlinx-coroutines          = "1.10.2"
 
 okio                        = "3.11.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,4 +95,6 @@ if (CHECK_PUBLICATION != null) {
     ).forEach { module ->
         include(":tools:$module")
     }
+
+    include(":test-android")
 }

--- a/test-android/.gitignore
+++ b/test-android/.gitignore
@@ -1,0 +1,2 @@
+build/
+src/androidInstrumentedTest/jniLibs/

--- a/test-android/api/test-android.klib.api
+++ b/test-android/api/test-android.klib.api
@@ -1,0 +1,10 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.matthewnelson.kmp-tor:test-android>
+final fun io.matthewnelson.kmp.tor.resource.test.android/Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_checkLoaded(): kotlin/Int // io.matthewnelson.kmp.tor.resource.test.android/Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_checkLoaded|Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_checkLoaded(){}[0]
+final fun io.matthewnelson.kmp.tor.resource.test.android/Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_executeNative(): kotlin/Int // io.matthewnelson.kmp.tor.resource.test.android/Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_executeNative|Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_executeNative(){}[0]

--- a/test-android/build.gradle.kts
+++ b/test-android/build.gradle.kts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+import com.android.build.gradle.tasks.MergeSourceSetFolders
+import io.matthewnelson.kmp.configuration.extension.container.target.TargetAndroidNativeContainer
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+plugins {
+    id("configuration")
+}
+
+kmpConfiguration {
+    configure {
+        val jniLibsDir = projectDir
+            .resolve("src")
+            .resolve("androidInstrumentedTest")
+            .resolve("jniLibs")
+
+        project.tasks.all {
+            if (name != "clean") return@all
+            jniLibsDir.deleteRecursively()
+        }
+
+        androidLibrary(namespace = "io.matthewnelson.kmp.tor.resource.test.android") {
+            android {
+                packaging.jniLibs.useLegacyPackaging = false
+                sourceSets["androidTest"].jniLibs.srcDir(jniLibsDir)
+            }
+
+            sourceSetMain {
+                dependencies {
+
+                }
+            }
+
+            sourceSetTestInstrumented {
+                dependencies {
+                    implementation(libs.androidx.test.runner)
+                    implementation(kotlin("test"))
+                }
+            }
+        }
+
+        fun <T: KotlinNativeTarget> TargetAndroidNativeContainer<T>.setup() {
+            target {
+                binaries {
+                    sharedLib {
+                        baseName = "testjni"
+                    }
+                }
+                // -Wno-return-type
+                compilerOptions.suppressWarnings.set(true)
+            }
+        }
+
+        androidNativeArm32 { setup() }
+        androidNativeArm64 { setup() }
+        androidNativeX64 { setup() }
+        androidNativeX86 { setup() }
+
+        common {
+            sourceSetMain {
+                dependencies {
+                    implementation(project(":library:resource-noexec-tor"))
+                }
+            }
+        }
+
+        kotlin {
+            if (!project.plugins.hasPlugin("com.android.base")) return@kotlin
+
+            val buildDir = project
+                .layout
+                .buildDirectory
+                .asFile.get()
+
+            val nativeBinaryTasks = listOf(
+                "Arm32" to "armeabi-v7a",
+                "Arm64" to "arm64-v8a",
+                "X64" to "x86_64",
+                "X86" to "x86",
+            ).mapNotNull { (arch, abi) ->
+                val nativeBinaryTask = project
+                    .tasks
+                    .findByName("androidNative${arch}MainBinaries")
+                    ?: return@mapNotNull null
+
+                val abiDir = jniLibsDir.resolve(abi)
+                if (!abiDir.exists() && !abiDir.mkdirs()) throw RuntimeException("mkdirs[$abiDir]")
+
+                val lib = buildDir
+                    .resolve("bin")
+                    .resolve("androidNative${arch}")
+                    .resolve("releaseShared")
+                    .resolve("libtestjni.so")
+
+                nativeBinaryTask.doLast {
+                    lib.copyTo(abiDir.resolve(lib.name), overwrite = true)
+                }
+
+                nativeBinaryTask
+            }
+
+            project.tasks.withType(MergeSourceSetFolders::class.java).all {
+                if (name != "mergeDebugAndroidTestJniLibFolders") return@all
+                nativeBinaryTasks.forEach { task -> this.dependsOn(task) }
+            }
+        }
+
+        kotlin {
+            try {
+                project.evaluationDependsOn(":library:resource-compilation-lib-tor")
+            } catch (_: Throwable) {}
+
+            project.afterEvaluate {
+                val isUsingMocks = project(":library:resource-compilation-lib-tor")
+                    .layout
+                    .buildDirectory
+                    .asFile.get()
+                    .resolve("reports")
+                    .resolve("resource-validation")
+                    .resolve("resource-compilation-lib-tor")
+                    .resolve("android.err")
+                    .readText()
+                    .isNotBlank()
+
+                val srcDir = project
+                    .layout
+                    .buildDirectory
+                    .asFile.get()
+                    .resolve("generated")
+                    .resolve("sources")
+                    .resolve("buildConfig")
+                    .resolve("androidInstrumentedTest")
+                    .resolve("kotlin")
+
+                val packageName = "io.matthewnelson.kmp.tor.resource.test.android.internal"
+                var configDir = srcDir
+                packageName.split('.').forEach { segment ->
+                    configDir = configDir.resolve(segment)
+                }
+                configDir.mkdirs()
+                configDir.resolve("TestBuildConfig.kt").writeText("""
+                    package $packageName
+
+                    internal const val IS_USING_MOCK_RESOURCES: Boolean = $isUsingMocks
+
+                """.trimIndent())
+
+                sourceSets.findByName("androidInstrumentedTest")?.kotlin?.srcDir(srcDir)
+            }
+        }
+
+        kotlin { explicitApi() }
+    }
+}

--- a/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/resource/test/android/AndroidNoExecJniTest.kt
+++ b/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/resource/test/android/AndroidNoExecJniTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.resource.test.android
+
+import android.os.Build
+import dalvik.annotation.optimization.CriticalNative
+import dalvik.system.BaseDexClassLoader
+import io.matthewnelson.kmp.file.SysTempDir
+import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+import io.matthewnelson.kmp.tor.resource.noexec.tor.ResourceLoaderTorNoExec
+import io.matthewnelson.kmp.tor.resource.test.android.internal.IS_USING_MOCK_RESOURCES
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AndroidNoExecJniTest {
+
+    private companion object BINDER: ResourceLoader.RuntimeBinder {
+
+        @JvmStatic
+        @CriticalNative
+        private external fun executeNative(): Int
+
+        @JvmStatic
+        @CriticalNative
+        private external fun checkLoaded(): Int
+
+        private val IS_LOADED: Boolean by lazy {
+            try {
+                System.loadLibrary("testjni")
+                check(checkLoaded() == 0) { "checkLoaded was not 0" }
+                true
+            } catch (t: Throwable) {
+                t.printStackTrace()
+                false
+            }
+        }
+
+        private val LOADER: ResourceLoader.Tor.NoExec by lazy {
+            val dir = SysTempDir.resolve("android_emulator")
+            ResourceLoaderTorNoExec.getOrCreate(dir) as ResourceLoader.Tor.NoExec
+        }
+    }
+
+    @Test
+    fun givenLibTor_whenLegacyPackaging_thenIsUncompressedAndAlignedIfApi23OrAbove() {
+        var cl: ClassLoader? = this::class.java.classLoader
+        var libTor: File? = null
+        while (cl != null) {
+            if (cl is BaseDexClassLoader && libTor == null) {
+                libTor = cl.findLibrary("tor")?.let { File(it) }
+            }
+            cl = cl.parent
+        }
+
+        assertNotNull(libTor)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            // jni legacy packaging not available and should have installed
+            // libs to the ApplicationInfo.nativeLibraryDir
+            assertTrue(libTor.exists())
+            return
+        }
+
+        // Check we're not using legacy packaging (i.e. libtor.so is uncompressed in the base.apk zip)
+        // This, coupled with other tests ensures that, given all other tests passing, ensures that
+        // kmp_tor.c call to dlopen using the uncompressed and aligned libtor.so works properly.
+        assertFalse(libTor.exists())
+        assertTrue(libTor.path.contains("base.apk!/lib/"))
+    }
+
+    @Test
+    fun givenNoExecTor_whenUsingAndroidNativeJni_thenLibTorLoadsSuccessfullyEvenWhenLegacyPackagingFalse() {
+        assertTrue(IS_LOADED, "[libtestjni.so].IS_LOADED != true")
+
+        if (IS_USING_MOCK_RESOURCES) {
+            println("Skipping...")
+            return
+        }
+
+        val result = executeNative()
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun givenNoExecTor_whenUsingAndroid_thenLibTorLoadsSuccessfullyWhenLegacyPackagingFalse() {
+        if (IS_USING_MOCK_RESOURCES) {
+            println("Skipping...")
+            return
+        }
+
+        val result = LOADER.withApi(BINDER) {
+            torRunMain(listOf("--version"))
+            terminateAndAwaitResult()
+        }
+
+        assertEquals(0, result)
+    }
+}

--- a/test-android/src/androidMain/AndroidManifest.xml
+++ b/test-android/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+-->
+<manifest />

--- a/test-android/src/androidNativeMain/kotlin/io/matthewnelson/kmp/tor/resource/test/android/AndroidNativePlatform.kt
+++ b/test-android/src/androidNativeMain/kotlin/io/matthewnelson/kmp/tor/resource/test/android/AndroidNativePlatform.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("FunctionName", "SpellCheckingInspection", "UNUSED")
+
+package io.matthewnelson.kmp.tor.resource.test.android
+
+import io.matthewnelson.kmp.file.SysTempDir
+import io.matthewnelson.kmp.file.resolve
+import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+import io.matthewnelson.kmp.tor.resource.noexec.tor.ResourceLoaderTorNoExec
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.android.jint
+import kotlin.experimental.ExperimentalNativeApi
+
+private object BINDER: ResourceLoader.RuntimeBinder
+
+private val LOADER: ResourceLoader.Tor.NoExec by lazy {
+    ResourceLoaderTorNoExec.getOrCreate(SysTempDir.resolve("test_jni")) as ResourceLoader.Tor.NoExec
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@CName("Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_executeNative")
+public fun Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_executeNative(): jint = try {
+    LOADER.withApi(BINDER) {
+
+        try {
+            torRunMain(listOf("--version"))
+        } catch (t: Throwable) {
+            t.printStackTrace()
+            return@withApi -10
+        }
+
+        println("TorApi.State." + state().name)
+
+        terminateAndAwaitResult()
+    }
+} catch (t: Throwable) {
+    t.printStackTrace()
+    -20
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@CName("Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_checkLoaded")
+public fun Java_io_matthewnelson_kmp_tor_resource_test_android_AndroidNoExecJniTest_checkLoaded(): jint {
+    return 0
+}


### PR DESCRIPTION
Just some tests to ensure that all native libraries (`libtor.so` & `libtorjni.so`) load properly when they are packaged in an uncompressed & aligned manner (API 23+).