### PR TITLE
Deprecate `-noexec` shutdownhook registration for Jvm/Android

### DIFF
--- a/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
+++ b/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "RemoveRedundantQualifierName")
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "RemoveRedundantQualifierName", "DEPRECATION")
 
 package io.matthewnelson.kmp.tor.resource.noexec.tor
 
@@ -43,6 +43,7 @@ public actual class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
         )
 
         @JvmStatic
+        @Deprecated("ShutdownHook registration causes abnormal application exit behavior for Java/Android")
         public fun getOrCreate(
             resourceDir: File,
             registerShutdownHook: Boolean,

--- a/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
+++ b/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
@@ -39,7 +39,7 @@ public actual class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
             resourceDir: File,
         ): ResourceLoader.Tor = getOrCreate(
             resourceDir = resourceDir,
-            registerShutdownHook = true,
+            registerShutdownHook = false,
         )
 
         @JvmStatic


### PR DESCRIPTION
Closes #148 