### PR TITLE
Deprecate `ResourceLoaderTorNoExec.getOrCreate` for `JVM`

### DIFF
--- a/library/resource-noexec-tor-gpl/api/android/resource-noexec-tor-gpl.api
+++ b/library/resource-noexec-tor-gpl/api/android/resource-noexec-tor-gpl.api
@@ -1,10 +1,15 @@
+public abstract class io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
+	public abstract fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+	public abstract fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+}
+
 public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec : io/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor$NoExec {
 	public static final field Companion Lio/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion;
 	public static final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public static final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }
 
-public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion {
+public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion : io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
 	public final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }

--- a/library/resource-noexec-tor-gpl/api/jvm/resource-noexec-tor-gpl.api
+++ b/library/resource-noexec-tor-gpl/api/jvm/resource-noexec-tor-gpl.api
@@ -1,10 +1,15 @@
+public abstract class io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
+	public abstract fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+	public abstract fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+}
+
 public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec : io/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor$NoExec {
 	public static final field Companion Lio/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion;
 	public static final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public static final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }
 
-public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion {
+public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion : io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
 	public final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }

--- a/library/resource-noexec-tor-gpl/api/resource-noexec-tor-gpl.klib.api
+++ b/library/resource-noexec-tor-gpl/api/resource-noexec-tor-gpl.klib.api
@@ -7,13 +7,22 @@
 // - Show declarations: true
 
 // Library unique name: <io.matthewnelson.kmp-tor:resource-noexec-tor-gpl>
-// Targets: [native]
 final class io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec : io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor.NoExec { // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec|null[0]
-    final object Companion { // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion|null[0]
+    // Targets: [native]
+    final object Companion : io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate { // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion|null[0]
         final fun getOrCreate(io.matthewnelson.kmp.file/File): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File){}[0]
         final fun getOrCreate(io.matthewnelson.kmp.file/File, kotlin/Boolean): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File;kotlin.Boolean){}[0]
     }
+
+    // Targets: [js]
+    final object Companion : io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion|null[0]
+}
+
+// Targets: [native]
+abstract class io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate { // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate|null[0]
+    abstract fun getOrCreate(io.matthewnelson.kmp.file/File): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File){}[0]
+    abstract fun getOrCreate(io.matthewnelson.kmp.file/File, kotlin/Boolean): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File;kotlin.Boolean){}[0]
 }
 
 // Targets: [js]
-final class io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec : io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor.NoExec // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec|null[0]
+abstract class io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate|null[0]

--- a/library/resource-noexec-tor/api/android/resource-noexec-tor.api
+++ b/library/resource-noexec-tor/api/android/resource-noexec-tor.api
@@ -1,10 +1,15 @@
+public abstract class io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
+	public abstract fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+	public abstract fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+}
+
 public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec : io/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor$NoExec {
 	public static final field Companion Lio/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion;
 	public static final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public static final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }
 
-public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion {
+public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion : io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
 	public final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }

--- a/library/resource-noexec-tor/api/jvm/resource-noexec-tor.api
+++ b/library/resource-noexec-tor/api/jvm/resource-noexec-tor.api
@@ -1,10 +1,15 @@
+public abstract class io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
+	public abstract fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+	public abstract fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
+}
+
 public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec : io/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor$NoExec {
 	public static final field Companion Lio/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion;
 	public static final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public static final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }
 
-public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion {
+public final class io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec$Companion : io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate {
 	public final fun getOrCreate (Ljava/io/File;)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 	public final fun getOrCreate (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/common/api/ResourceLoader$Tor;
 }

--- a/library/resource-noexec-tor/api/resource-noexec-tor.klib.api
+++ b/library/resource-noexec-tor/api/resource-noexec-tor.klib.api
@@ -7,13 +7,22 @@
 // - Show declarations: true
 
 // Library unique name: <io.matthewnelson.kmp-tor:resource-noexec-tor>
-// Targets: [native]
 final class io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec : io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor.NoExec { // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec|null[0]
-    final object Companion { // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion|null[0]
+    // Targets: [native]
+    final object Companion : io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate { // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion|null[0]
         final fun getOrCreate(io.matthewnelson.kmp.file/File): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File){}[0]
         final fun getOrCreate(io.matthewnelson.kmp.file/File, kotlin/Boolean): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File;kotlin.Boolean){}[0]
     }
+
+    // Targets: [js]
+    final object Companion : io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec.Companion|null[0]
+}
+
+// Targets: [native]
+abstract class io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate { // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate|null[0]
+    abstract fun getOrCreate(io.matthewnelson.kmp.file/File): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File){}[0]
+    abstract fun getOrCreate(io.matthewnelson.kmp.file/File, kotlin/Boolean): io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate.getOrCreate|getOrCreate(io.matthewnelson.kmp.file.File;kotlin.Boolean){}[0]
 }
 
 // Targets: [js]
-final class io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec : io.matthewnelson.kmp.tor.common.api/ResourceLoader.Tor.NoExec // io.matthewnelson.kmp.tor.resource.noexec.tor/ResourceLoaderTorNoExec|null[0]
+abstract class io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate // io.matthewnelson.kmp.tor.resource.noexec.tor/GetOrCreate|null[0]

--- a/library/resource-noexec-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
+++ b/library/resource-noexec-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "RemoveRedundantQualifierName", "DEPRECATION", "RedundantModalityModifier")
+
+package io.matthewnelson.kmp.tor.resource.noexec.tor
+
+import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.absoluteFile2
+import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+import io.matthewnelson.kmp.tor.common.api.TorApi
+import io.matthewnelson.kmp.tor.resource.noexec.tor.internal.KmpTorApi
+import io.matthewnelson.kmp.tor.resource.noexec.tor.internal.noExecExtractGeoips
+import io.matthewnelson.kmp.tor.resource.noexec.tor.internal.noExecToString
+import kotlin.jvm.JvmStatic
+
+// androidMain
+public actual class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
+
+    public actual companion object: GetOrCreate() {
+
+        /**
+         * Creates a new instance of [ResourceLoaderTorNoExec] with provided [resourceDir]. If
+         * an instance of [ResourceLoader.Tor] already exists, that will be returned instead.
+         *
+         * @param [resourceDir] The directory to extract resources to.
+         *
+         * @throws [IOException] If [absoluteFile2] has to reference the filesystem to construct
+         *   an absolute path and fails due to a filesystem security exception.
+         * */
+        @JvmStatic
+        public final override fun getOrCreate(
+            resourceDir: File,
+        ): ResourceLoader.Tor = getOrCreate(
+            resourceDir = resourceDir,
+            registerShutdownHook = false,
+        )
+
+        /**
+         * DEPRECATED
+         *
+         * Creates a new instance of [ResourceLoaderTorNoExec] with provided [resourceDir]. If
+         * an instance of [ResourceLoader.Tor] already exists, that will be returned instead.
+         *
+         * @param [resourceDir] The directory to extract resources to.
+         * @param [registerShutdownHook] If `true`, a shutdown hook will be registered for Jvm/Android
+         *   which will call [TorApi.terminateAndAwaitResult].
+         *
+         * @throws [IOException] If [absoluteFile2] has to reference the filesystem to construct
+         *   an absolute path and fails due to a filesystem security exception.
+         * @suppress
+         * */
+        @JvmStatic
+        @Deprecated("ShutdownHook registration causes abnormal application exit behavior for Java/Android")
+        public final override fun getOrCreate(
+            resourceDir: File,
+            registerShutdownHook: Boolean,
+        ): ResourceLoader.Tor = NoExec.getOrCreate(
+            resourceDir = resourceDir,
+            extract = ::noExecExtractGeoips,
+            create = { dir -> KmpTorApi.of(dir, registerShutdownHook) },
+            toString = ::noExecToString,
+        )
+    }
+
+    @Throws(IllegalStateException::class)
+    @Suppress("ConvertSecondaryConstructorToPrimary", "UnnecessaryOptInAnnotation", "unused")
+    private actual constructor()
+}

--- a/library/resource-noexec-tor/src/commonMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate.kt
+++ b/library/resource-noexec-tor/src/commonMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Matthew Nelson
+ * Copyright (c) 2025 Matthew Nelson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,4 @@
 
 package io.matthewnelson.kmp.tor.resource.noexec.tor
 
-import io.matthewnelson.kmp.tor.common.api.ResourceLoader
-
-// commonMain
-public expect class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
-
-    public companion object: GetOrCreate
-
-    @Throws(IllegalStateException::class)
-    @Suppress("ConvertSecondaryConstructorToPrimary", "UnnecessaryOptInAnnotation", "unused")
-    private constructor()
-}
+public expect abstract class GetOrCreate internal constructor()

--- a/library/resource-noexec-tor/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
+++ b/library/resource-noexec-tor/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "RemoveRedundantQualifierName", "DEPRECATION")
+
+package io.matthewnelson.kmp.tor.resource.noexec.tor
+
+import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.absoluteFile2
+import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+import io.matthewnelson.kmp.tor.common.api.TorApi
+import io.matthewnelson.kmp.tor.resource.noexec.tor.internal.KmpTorApi
+import io.matthewnelson.kmp.tor.resource.noexec.tor.internal.noExecExtractGeoips
+import io.matthewnelson.kmp.tor.resource.noexec.tor.internal.noExecToString
+
+// nativeMain
+public actual class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
+
+    public actual companion object: GetOrCreate() {
+
+        /**
+         * Creates a new instance of [ResourceLoaderTorNoExec] with provided [resourceDir]. If
+         * an instance of [ResourceLoader.Tor] already exists, that will be returned instead.
+         *
+         * @param [resourceDir] The directory to extract resources to.
+         *
+         * @throws [IOException] If [absoluteFile2] has to reference the filesystem to construct
+         *   an absolute path and fails due to a filesystem security exception.
+         * */
+        public override fun getOrCreate(
+            resourceDir: File,
+        ): ResourceLoader.Tor = getOrCreate(
+            resourceDir = resourceDir,
+            registerShutdownHook = false,
+        )
+
+        /**
+         * DEPRECATED
+         *
+         * Creates a new instance of [ResourceLoaderTorNoExec] with provided [resourceDir]. If
+         * an instance of [ResourceLoader.Tor] already exists, that will be returned instead.
+         *
+         * @param [resourceDir] The directory to extract resources to.
+         * @param [registerShutdownHook] If `true`, a shutdown hook will be registered for Jvm/Android
+         *   which will call [TorApi.terminateAndAwaitResult].
+         *
+         * @throws [IOException] If [absoluteFile2] has to reference the filesystem to construct
+         *   an absolute path and fails due to a filesystem security exception.
+         * @suppress
+         * */
+        @Deprecated("ShutdownHook registration causes abnormal application exit behavior for Java/Android")
+        public override fun getOrCreate(
+            resourceDir: File,
+            registerShutdownHook: Boolean,
+        ): ResourceLoader.Tor = NoExec.getOrCreate(
+            resourceDir = resourceDir,
+            extract = ::noExecExtractGeoips,
+            create = { dir -> KmpTorApi.of(dir, registerShutdownHook) },
+            toString = ::noExecToString,
+        )
+    }
+
+    @Throws(IllegalStateException::class)
+    @Suppress("ConvertSecondaryConstructorToPrimary", "UnnecessaryOptInAnnotation", "unused")
+    private actual constructor()
+}

--- a/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate.kt
+++ b/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.resource.noexec.tor
+
+import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.absoluteFile2
+import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+import io.matthewnelson.kmp.tor.common.api.TorApi
+
+// noExecMain
+/**
+ * See [ResourceLoaderTorNoExec]
+ * */
+public actual abstract class GetOrCreate internal actual constructor() {
+
+    /**
+     * Creates a new instance of [ResourceLoaderTorNoExec] with provided [resourceDir]. If
+     * an instance of [ResourceLoader.Tor] already exists, that will be returned instead.
+     *
+     * @param [resourceDir] The directory to extract resources to.
+     *
+     * @throws [IOException] If [absoluteFile2] has to reference the filesystem to construct
+     *   an absolute path and fails due to a filesystem security exception.
+     * */
+    public abstract fun getOrCreate(
+        resourceDir: File
+    ): ResourceLoader.Tor
+
+    /**
+     * DEPRECATED
+     *
+     * Creates a new instance of [ResourceLoaderTorNoExec] with provided [resourceDir]. If
+     * an instance of [ResourceLoader.Tor] already exists, that will be returned instead.
+     *
+     * @param [resourceDir] The directory to extract resources to.
+     * @param [registerShutdownHook] If `true`, a shutdown hook will be registered for Jvm/Android
+     *   which will call [TorApi.terminateAndAwaitResult].
+     *
+     * @throws [IOException] If [absoluteFile2] has to reference the filesystem to construct
+     *   an absolute path and fails due to a filesystem security exception.
+     * @suppress
+     * */
+    @Deprecated("ShutdownHook registration causes abnormal application exit behavior for Java/Android")
+    public abstract fun getOrCreate(
+        resourceDir: File,
+        registerShutdownHook: Boolean,
+    ): ResourceLoader.Tor
+}

--- a/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/internal/-NoExecResourceLoader.kt
+++ b/library/resource-noexec-tor/src/noExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/internal/-NoExecResourceLoader.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.resource.noexec.tor.internal
+
+import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.tor.common.api.GeoipFiles
+import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.resource.geoip.ALIAS_GEOIP
+import io.matthewnelson.kmp.tor.resource.geoip.ALIAS_GEOIP6
+import kotlin.concurrent.Volatile
+
+@Volatile
+private var IS_FIRST_EXTRACTION: Boolean = true
+
+@OptIn(InternalKmpTorApi::class)
+internal fun noExecExtractGeoips(resourceDir: File): GeoipFiles {
+    val map = RESOURCE_CONFIG_GEOIPS
+        .extractTo(resourceDir, onlyIfDoesNotExist = !IS_FIRST_EXTRACTION)
+
+    IS_FIRST_EXTRACTION = false
+
+    return GeoipFiles(
+        geoip = map.getValue(ALIAS_GEOIP),
+        geoip6 = map.getValue(ALIAS_GEOIP6),
+    )
+}
+
+@OptIn(InternalKmpTorApi::class)
+internal fun noExecToString(resourceDir: File): String = buildString {
+    appendLine("ResourceLoader.Tor.NoExec: [")
+    append("    resourceDir: ")
+    appendLine(resourceDir)
+
+    RESOURCE_CONFIG_GEOIPS.toString().lines().let { lines ->
+        appendLine("    configGeoips: [")
+        for (i in 1 until lines.size) {
+            append("    ")
+            appendLine(lines[i])
+        }
+    }
+
+    RESOURCE_CONFIG_LIB_TOR.let { config ->
+        // Android may have an empty configuration if not using
+        // test resources. iOS and androidNative are always empty;
+        // do not include if that is the case.
+        if (config.errors.isEmpty() && config.resources.isEmpty()) return@let
+
+        val lines = config.toString().lines()
+        appendLine("    configLibTor: [")
+        for (i in 1 until lines.size) {
+            append("    ")
+            appendLine(lines[i])
+        }
+    }
+
+    append(']')
+}

--- a/library/resource-noexec-tor/src/nonNoExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate.kt
+++ b/library/resource-noexec-tor/src/nonNoExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/GetOrCreate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Matthew Nelson
+ * Copyright (c) 2025 Matthew Nelson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,9 @@
 
 package io.matthewnelson.kmp.tor.resource.noexec.tor
 
-import io.matthewnelson.kmp.tor.common.api.ResourceLoader
+// nonNoExecMain
+public actual abstract class GetOrCreate internal actual constructor() {
 
-// commonMain
-public expect class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
+    // no-op
 
-    public companion object: GetOrCreate
-
-    @Throws(IllegalStateException::class)
-    @Suppress("ConvertSecondaryConstructorToPrimary", "UnnecessaryOptInAnnotation", "unused")
-    private constructor()
 }

--- a/library/resource-noexec-tor/src/nonNoExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
+++ b/library/resource-noexec-tor/src/nonNoExecMain/kotlin/io/matthewnelson/kmp/tor/resource/noexec/tor/ResourceLoaderTorNoExec.kt
@@ -22,6 +22,8 @@ import io.matthewnelson.kmp.tor.common.api.ResourceLoader
 // nonNoExecMain
 public actual class ResourceLoaderTorNoExec: ResourceLoader.Tor.NoExec {
 
+    public actual companion object: GetOrCreate()
+
 //    @Throws(IllegalStateException::class)
     @Suppress("ConvertSecondaryConstructorToPrimary", "UnnecessaryOptInAnnotation", "unused")
     private actual constructor()


### PR DESCRIPTION
Closes #156 